### PR TITLE
feat: wave 9 -- 10 quick-win spec compliance fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Attractor lets you define AI workflows as Graphviz DOT files. Each node in the g
 digraph Pipeline {
     graph [goal="Build a REST API"]
 
-    start [shape=ellipse]
+    start [shape=Mdiamond]
     plan [shape=box, prompt="Create a plan for: $goal"]
     implement [shape=box, prompt="Write the code for: $goal"]
     review [shape=diamond]
@@ -67,7 +67,7 @@ uv run python -m attractor_server --port 8080
 # Submit a pipeline
 curl -X POST http://localhost:8080/pipelines \
   -H "Content-Type: application/json" \
-  -d '{"dot_source": "digraph { start [shape=ellipse]; task [shape=box, prompt=\"Write a haiku\"]; done [shape=Msquare]; start -> task -> done }"}'
+  -d '{"dot_source": "digraph { start [shape=Mdiamond]; task [shape=box, prompt=\"Write a haiku\"]; done [shape=Msquare]; start -> task -> done }"}'
 
 # Watch events in real-time (SSE)
 curl -N http://localhost:8080/pipelines/{id}/events
@@ -117,7 +117,7 @@ Late-connecting SSE clients receive the full event history replay.
 
 | Shape | Node Type | What It Does |
 |-------|-----------|-------------|
-| `ellipse` | Start | Entry point (no-op) |
+| `Mdiamond` | Start | Entry point (no-op) |
 | `box` | Codergen | Calls an LLM with the node's prompt |
 | `diamond` | Conditional | Branches based on edge conditions |
 | `house` | Human Gate | Waits for human approval (CLI or HTTP) |
@@ -134,7 +134,7 @@ Node prompts support `$variable` and `${variable}` expansion from the pipeline c
 ```dot
 digraph {
     graph [goal="Build a CLI tool"]
-    start [shape=ellipse]
+    start [shape=Mdiamond]
     plan [shape=box, prompt="Plan: $goal"]
     implement [shape=box, prompt="Implement: $goal using ${language}"]
     done [shape=Msquare]
@@ -170,7 +170,7 @@ Specificity: `*` (0) < `shape` (1) < `.class` (2) < `#id` (3). Explicit node att
 
 ```dot
 digraph {
-    start [shape=ellipse]
+    start [shape=Mdiamond]
     fork [shape=component]
     a [shape=box, prompt="Approach A"]
     b [shape=box, prompt="Approach B"]
@@ -192,7 +192,7 @@ A hexagon node runs a child pipeline and retries if it fails:
 
 ```dot
 digraph {
-    start [shape=ellipse]
+    start [shape=Mdiamond]
     supervisor [shape=hexagon, child_graph="child.dot", max_iterations="3"]
     done [shape=Msquare]
     start -> supervisor -> done

--- a/examples/code_review.dot
+++ b/examples/code_review.dot
@@ -8,7 +8,7 @@ digraph CodeReview {
         max_goal_gate_redirects="3"
     ]
 
-    start [shape=ellipse, label="Start"]
+    start [shape=Mdiamond, label="Start"]
 
     implement [
         shape=box,

--- a/examples/codebase_to_spec.dot
+++ b/examples/codebase_to_spec.dot
@@ -33,7 +33,7 @@ digraph codebase_to_spec {
 
     // ── Entry ──────────────────────────────────────────────────
 
-    start [shape=ellipse label="Start"]
+    start [shape=Mdiamond label="Start"]
 
     // ── Phase 1: Discover ──────────────────────────────────────
     //

--- a/examples/conditional_goal_gate.dot
+++ b/examples/conditional_goal_gate.dot
@@ -11,7 +11,7 @@
 digraph ConditionalGoalGate {
     graph [goal="Write a thread-safe LRU cache in Python", max_goal_gate_redirects="3"]
 
-    start [shape=ellipse]
+    start [shape=Mdiamond]
 
     plan [
         shape=box,

--- a/examples/e2e_test.py
+++ b/examples/e2e_test.py
@@ -73,7 +73,7 @@ async def main() -> None:
     digraph FeaturePipeline {
         graph [goal="Write a Python function that calculates fibonacci numbers"]
 
-        start [shape=ellipse, label="Start"]
+        start [shape=Mdiamond, label="Start"]
 
         plan [
             shape=box,

--- a/examples/fibonacci.dot
+++ b/examples/fibonacci.dot
@@ -4,7 +4,7 @@
 digraph Fibonacci {
     graph [goal="Write a Python function that calculates fibonacci numbers"]
 
-    start [shape=ellipse, label="Start"]
+    start [shape=Mdiamond, label="Start"]
 
     plan [
         shape=box,

--- a/examples/human_approval.dot
+++ b/examples/human_approval.dot
@@ -10,7 +10,7 @@
 digraph HumanApproval {
     graph [goal="Deploy database migration to production"]
 
-    start [shape=ellipse]
+    start [shape=Mdiamond]
 
     generate_migration [
         shape=box,

--- a/examples/model_stylesheet.dot
+++ b/examples/model_stylesheet.dot
@@ -17,7 +17,7 @@ digraph ModelStylesheet {
         "
     ]
 
-    start [shape=ellipse]
+    start [shape=Mdiamond]
 
     // Gets * defaults: claude-sonnet-4-5
     plan [shape=box, prompt="Create an architecture plan for: $goal"]

--- a/examples/parallel_approaches.dot
+++ b/examples/parallel_approaches.dot
@@ -9,7 +9,7 @@
 digraph ParallelApproaches {
     graph [goal="Write a Python function that finds the longest palindromic substring"]
 
-    start [shape=ellipse]
+    start [shape=Mdiamond]
 
     fork [shape=component, label="Fan out"]
 

--- a/examples/prompt_layering.dot
+++ b/examples/prompt_layering.dot
@@ -15,7 +15,7 @@
 digraph PromptLayering {
     graph [goal="Build a URL shortener microservice"]
 
-    start [shape=ellipse]
+    start [shape=Mdiamond]
 
     // This node gets a node-specific instruction on top of the profile + goal
     architect [

--- a/examples/research_then_build.dot
+++ b/examples/research_then_build.dot
@@ -5,7 +5,7 @@
 digraph ResearchThenBuild {
     graph [goal="Build a CLI tool that converts CSV files to JSON"]
 
-    start [shape=ellipse, label="Start"]
+    start [shape=Mdiamond, label="Start"]
 
     research [
         shape=box,

--- a/examples/software_factory.dot
+++ b/examples/software_factory.dot
@@ -9,7 +9,7 @@
 digraph SoftwareFactory {
     graph [goal="Build a Python CLI tool that converts CSV files to JSON"]
 
-    start [shape=ellipse]
+    start [shape=Mdiamond]
 
     research [
         shape=box,

--- a/examples/spec_driven_dev.dot
+++ b/examples/spec_driven_dev.dot
@@ -22,7 +22,7 @@ digraph spec_driven_dev {
 
     // ── Entry ──────────────────────────────────────────────────
 
-    start [shape=ellipse label="Start"]
+    start [shape=Mdiamond label="Start"]
 
     // ── Phase 1: Catalog ───────────────────────────────────────
     //

--- a/examples/supervisor_child.dot
+++ b/examples/supervisor_child.dot
@@ -6,7 +6,7 @@
 digraph ChildPipeline {
     graph [goal="$goal"]
 
-    start [shape=ellipse]
+    start [shape=Mdiamond]
 
     design [
         shape=box,

--- a/examples/supervisor_loop.dot
+++ b/examples/supervisor_loop.dot
@@ -11,7 +11,7 @@
 digraph SupervisorLoop {
     graph [goal="Write a robust input validation module"]
 
-    start [shape=ellipse]
+    start [shape=Mdiamond]
 
     supervisor [
         shape=hexagon,

--- a/examples/variable_expansion.dot
+++ b/examples/variable_expansion.dot
@@ -13,7 +13,7 @@
 digraph VariableExpansion {
     graph [goal="Build a Python utility"]
 
-    start [shape=ellipse]
+    start [shape=Mdiamond]
 
     // Stage 1: Define the spec. Output becomes available as $codergen.define_spec.output
     define_spec [

--- a/src/attractor_agent/profiles/anthropic.py
+++ b/src/attractor_agent/profiles/anthropic.py
@@ -74,8 +74,9 @@ class AnthropicProfile:
 # ------------------------------------------------------------------ #
 
 _ANTHROPIC_SYSTEM_PROMPT = """\
-You are an expert software engineer. You solve problems by writing \
-and editing code, running commands, and navigating codebases methodically.
+You are Claude, an AI assistant by Anthropic. You are an expert software \
+engineer. You solve problems by writing and editing code, running commands, \
+and navigating codebases methodically.
 
 WORKFLOW
 1. Understand first. Before making changes, read the relevant files \

--- a/src/attractor_agent/profiles/gemini.py
+++ b/src/attractor_agent/profiles/gemini.py
@@ -80,7 +80,8 @@ class GeminiProfile:
 # ------------------------------------------------------------------ #
 
 _GEMINI_SYSTEM_PROMPT = """\
-You are an expert software engineer acting as an autonomous coding agent.
+You are Gemini, an AI assistant by Google. You are an expert software \
+engineer acting as an autonomous coding agent.
 
 You have access to tools for reading, writing, editing files, running \
 shell commands, and searching codebases. Use them proactively.

--- a/src/attractor_agent/session.py
+++ b/src/attractor_agent/session.py
@@ -68,6 +68,9 @@ class SessionConfig:
     reasoning_effort: str | None = None
     provider_options: dict[str, Any] | None = None
 
+    # User-supplied instruction override -- appended LAST (layer 5, §9.8)
+    user_instructions: str = ""
+
     # Working directory for environment context (None = os.getcwd())
     working_dir: str | None = None
 
@@ -534,6 +537,10 @@ class Session:
         )
         if project_docs:
             parts.append(project_docs)
+
+        # 4. User instruction overrides -- appended LAST (layer 5, §9.8)
+        if self._config.user_instructions:
+            parts.append(self._config.user_instructions)
 
         return "\n\n".join(parts)
 

--- a/src/attractor_agent/truncation.py
+++ b/src/attractor_agent/truncation.py
@@ -38,9 +38,11 @@ class TruncationLimits:
             "read_file": cls(max_chars=50_000, max_lines=1000),
             "shell": cls(max_chars=30_000, max_lines=256),
             "grep": cls(max_chars=20_000, max_lines=200),
-            "glob": cls(max_chars=10_000, max_lines=500),
-            "write_file": cls(max_chars=5_000, max_lines=50),
-            "edit_file": cls(max_chars=5_000, max_lines=50),
+            "glob": cls(max_chars=20_000, max_lines=500),
+            "write_file": cls(max_chars=1_000, max_lines=50),
+            "edit_file": cls(max_chars=10_000, max_lines=50),
+            "apply_patch": cls(max_chars=10_000, max_lines=200),
+            "spawn_agent": cls(max_chars=20_000, max_lines=500),
         }
         preset = presets.get(tool_name, cls())
 
@@ -90,7 +92,12 @@ def truncate_output(
         head = output[:head_size]
         tail = output[-tail_size:] if tail_size > 0 else ""
         omitted = len(output) - head_size - tail_size
-        output = f"{head}\n\n[... {omitted:,} characters omitted ...]\n\n{tail}"
+        output = (
+            f"{head}\n\n[WARNING: Tool output was truncated. {omitted:,} characters "
+            f"were removed from the middle. The full output is available in the "
+            f"event stream. If you need to see specific parts, re-run the tool "
+            f"with more targeted parameters.]\n\n{tail}"
+        )
         truncated = True
 
     # Pass 2: Line-based truncation
@@ -102,7 +109,10 @@ def truncate_output(
         tail = lines[-tail_lines:] if tail_lines > 0 else []
         omitted_lines = len(lines) - head_lines - tail_lines
         output = (
-            "\n".join(head) + f"\n\n[... {omitted_lines:,} lines omitted ...]\n\n" + "\n".join(tail)
+            "\n".join(head) + f"\n\n[WARNING: Tool output was truncated. {omitted_lines:,} lines "
+            f"were removed from the middle. The full output is available in the "
+            f"event stream. If you need to see specific parts, re-run the tool "
+            f"with more targeted parameters.]\n\n" + "\n".join(tail)
         )
         truncated = True
 

--- a/src/attractor_llm/adapters/anthropic.py
+++ b/src/attractor_llm/adapters/anthropic.py
@@ -108,7 +108,9 @@ class AnthropicAdapter:
             elif request.tool_choice == "required":
                 body["tool_choice"] = {"type": "any"}
             elif request.tool_choice == "none":
-                body["tool_choice"] = {"type": "none"}
+                # Anthropic does not support tool_choice={type: none} when
+                # tools are present.  Omit the tools array instead (§8.7).
+                body.pop("tools", None)
             else:
                 body["tool_choice"] = {"type": "tool", "name": request.tool_choice}
 

--- a/src/attractor_pipeline/graph.py
+++ b/src/attractor_pipeline/graph.py
@@ -25,7 +25,7 @@ class NodeShape(StrEnum):
     PARALLELOGRAM = "parallelogram"  # tool (shell/script)
     HOUSE = "house"  # wait.human (human gate)
     MSQUARE = "Msquare"  # exit (terminal)
-    ELLIPSE = "ellipse"  # start (entry point)
+    MDIAMOND = "Mdiamond"  # start (entry point)
 
     @classmethod
     def handler_for_shape(cls, shape: str) -> str:
@@ -39,7 +39,7 @@ class NodeShape(StrEnum):
             "parallelogram": "tool",
             "house": "wait.human",
             "Msquare": "exit",
-            "ellipse": "start",
+            "Mdiamond": "start",
         }
         return mapping.get(shape, "codergen")
 
@@ -129,13 +129,13 @@ class Graph:
         return self.nodes.get(node_id)
 
     def get_start_node(self) -> Node | None:
-        """Find the start node (shape=ellipse only).
+        """Find the start node (shape=Mdiamond only).
 
-        The validator (R01) enforces that exactly one ellipse node exists.
+        The validator (R01) enforces that exactly one Mdiamond node exists.
         No name-based fallback -- the shape is the single source of truth.
         """
         for node in self.nodes.values():
-            if node.shape == "ellipse":
+            if node.shape == "Mdiamond":
                 return node
         return None
 

--- a/src/attractor_pipeline/handlers/basic.py
+++ b/src/attractor_pipeline/handlers/basic.py
@@ -21,7 +21,7 @@ from attractor_pipeline.graph import Graph, Node
 
 
 class StartHandler:
-    """Handler for start nodes (shape=ellipse). Spec §4.3.
+    """Handler for start nodes (shape=Mdiamond). Spec §4.3.
 
     The start handler is a no-op -- it simply passes through
     with SUCCESS status. Its purpose is to mark the entry point.

--- a/src/attractor_pipeline/handlers/manager.py
+++ b/src/attractor_pipeline/handlers/manager.py
@@ -8,7 +8,7 @@ composition -- a pipeline node that itself runs a pipeline.
 Usage in DOT::
 
     digraph Supervised {
-        start [shape=ellipse]
+        start [shape=Mdiamond]
         manager [
             shape=hexagon,
             child_graph="path/to/child.dot",

--- a/src/attractor_pipeline/validation.py
+++ b/src/attractor_pipeline/validation.py
@@ -78,14 +78,14 @@ def validate_or_raise(graph: Graph) -> None:
 
 
 def _rule_has_start_node(graph: Graph) -> list[Diagnostic]:
-    """R01: Graph must have exactly one start node (shape=ellipse)."""
-    start_nodes = [n for n in graph.nodes.values() if n.shape == "ellipse"]
+    """R01: Graph must have exactly one start node (shape=Mdiamond)."""
+    start_nodes = [n for n in graph.nodes.values() if n.shape == "Mdiamond"]
     if len(start_nodes) == 0:
         return [
             Diagnostic(
                 rule="R01",
                 severity=Severity.ERROR,
-                message="Graph has no start node (shape=ellipse)",
+                message="Graph has no start node (shape=Mdiamond)",
             )
         ]
     if len(start_nodes) > 1:
@@ -115,7 +115,7 @@ def _rule_has_exit_node(graph: Graph) -> list[Diagnostic]:
 
 
 def _rule_start_has_no_incoming(graph: Graph) -> list[Diagnostic]:
-    """R03: Start node should have no incoming edges."""
+    """R03: Start node must have no incoming edges."""
     start = graph.get_start_node()
     if start is None:
         return []
@@ -125,7 +125,7 @@ def _rule_start_has_no_incoming(graph: Graph) -> list[Diagnostic]:
         return [
             Diagnostic(
                 rule="R03",
-                severity=Severity.WARNING,
+                severity=Severity.ERROR,
                 message=f"Start node '{start.id}' has incoming edges from: {sources}",
                 node_id=start.id,
             )
@@ -134,7 +134,7 @@ def _rule_start_has_no_incoming(graph: Graph) -> list[Diagnostic]:
 
 
 def _rule_exit_has_no_outgoing(graph: Graph) -> list[Diagnostic]:
-    """R04: Exit nodes should have no outgoing edges."""
+    """R04: Exit nodes must have no outgoing edges."""
     results: list[Diagnostic] = []
     for node in graph.get_exit_nodes():
         outgoing = graph.outgoing_edges(node.id)
@@ -143,7 +143,7 @@ def _rule_exit_has_no_outgoing(graph: Graph) -> list[Diagnostic]:
             results.append(
                 Diagnostic(
                     rule="R04",
-                    severity=Severity.WARNING,
+                    severity=Severity.ERROR,
                     message=(f"Exit node '{node.id}' has outgoing edges to: {targets}"),
                     node_id=node.id,
                 )

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -117,14 +117,14 @@ class TestTruncation:
         long_text = "x" * 50_000
         result, truncated = truncate_output(long_text, TruncationLimits(max_chars=1000))
         assert truncated is True
-        assert len(result) < 1200
-        assert "characters omitted" in result
+        assert len(result) < 1400
+        assert "characters were removed from the middle" in result
 
     def test_line_truncation(self):
         many_lines = "\n".join(f"line {i}" for i in range(1000))
         result, truncated = truncate_output(many_lines, TruncationLimits(max_lines=100))
         assert truncated is True
-        assert "lines omitted" in result
+        assert "lines were removed from the middle" in result
 
     def test_empty_string(self):
         result, truncated = truncate_output("")

--- a/tests/test_aggressive.py
+++ b/tests/test_aggressive.py
@@ -413,7 +413,7 @@ class TestConcurrencyStress:
         g = parse_dot(f"""
         digraph Stress {{
             graph [goal="Stress test"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             fork [shape=component]
 {branch_nodes}
             join [shape=tripleoctagon]
@@ -470,7 +470,7 @@ class TestConcurrencyStress:
         g = parse_dot("""
         digraph Sem {
             graph [goal="Semaphore test"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             fork [shape=component, max_parallel="2"]
             a [shape=box, prompt="A"]
             b [shape=box, prompt="B"]

--- a/tests/test_dod_gaps.py
+++ b/tests/test_dod_gaps.py
@@ -68,7 +68,7 @@ class _FailNHandler:
 def _make_linear_graph() -> Graph:
     """A minimal graph: start -> work -> exit."""
     g = Graph(name="test", default_max_retry=5)
-    g.nodes["start"] = Node(id="start", shape="ellipse")
+    g.nodes["start"] = Node(id="start", shape="Mdiamond")
     g.nodes["work"] = Node(id="work", shape="box")
     g.nodes["exit"] = Node(id="exit", shape="Msquare")
     g.edges.append(Edge(source="start", target="work"))
@@ -673,7 +673,7 @@ class TestGoalGateAllNodes:
         pipeline to proceed through to the exit node.
         """
         g = Graph(name="test", default_max_retry=3, max_goal_gate_redirects=5)
-        g.nodes["start"] = Node(id="start", shape="ellipse")
+        g.nodes["start"] = Node(id="start", shape="Mdiamond")
         # 'check' node has a goal_gate but is NOT an exit node
         g.nodes["check"] = Node(
             id="check",
@@ -798,7 +798,7 @@ class TestPerNodeArtifacts:
             name="test",
             goal="test goal",
             nodes={
-                "start": Node(id="start", shape="ellipse"),
+                "start": Node(id="start", shape="Mdiamond"),
                 "my_node": Node(id="my_node", shape="box", prompt="Do something: ${goal}"),
                 "done": Node(id="done", shape="Msquare"),
             },
@@ -850,7 +850,7 @@ class TestPerNodeArtifacts:
         g = Graph(
             name="test",
             nodes={
-                "start": Node(id="start", shape="ellipse"),
+                "start": Node(id="start", shape="Mdiamond"),
                 "node1": Node(id="node1", shape="box", prompt="Do it"),
                 "done": Node(id="done", shape="Msquare"),
             },

--- a/tests/test_e2e_integration.py
+++ b/tests/test_e2e_integration.py
@@ -153,7 +153,7 @@ class TestPipelineWithAgentLoop:
         g = parse_dot(f"""
         digraph WriteCode {{
             graph [goal="Write a Python function"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             code [
                 shape=box,
                 prompt="Write a function called add that takes two numbers and returns their sum. Save it to {workspace}/add.py"
@@ -197,7 +197,7 @@ class TestMultiStagePipeline:
         g = parse_dot("""
         digraph Chained {
             graph [goal="Build a temperature converter"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             plan [
                 shape=box,
                 prompt="Create a brief 3-bullet plan for: $goal. Be very concise."
@@ -368,7 +368,7 @@ class TestSoftwareFactory:
         g = parse_dot("""
         digraph Factory {
             graph [goal="Write a Python function that checks if a string is a palindrome"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
 
             plan [
                 shape=box,

--- a/tests/test_loop_detector_validation.py
+++ b/tests/test_loop_detector_validation.py
@@ -90,7 +90,7 @@ class TestValidationR03:
         g = parse_dot("""
         digraph R03 {
             graph [goal="X"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             task [shape=box]
             done [shape=Msquare]
             start -> task -> done
@@ -100,13 +100,13 @@ class TestValidationR03:
         diags = validate(g)
         r03 = [d for d in diags if d.rule == "R03"]
         assert len(r03) == 1
-        assert r03[0].severity == Severity.WARNING
+        assert r03[0].severity == Severity.ERROR
 
     def test_clean_start_no_warning(self):
         g = parse_dot("""
         digraph Clean {
             graph [goal="X"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             done [shape=Msquare]
             start -> done
         }
@@ -123,7 +123,7 @@ class TestValidationR04:
         g = parse_dot("""
         digraph R04 {
             graph [goal="X"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             done [shape=Msquare]
             task [shape=box]
             start -> done
@@ -133,7 +133,7 @@ class TestValidationR04:
         diags = validate(g)
         r04 = [d for d in diags if d.rule == "R04"]
         assert len(r04) == 1
-        assert r04[0].severity == Severity.WARNING
+        assert r04[0].severity == Severity.ERROR
 
 
 class TestValidationR05:
@@ -143,7 +143,7 @@ class TestValidationR05:
         g = parse_dot("""
         digraph R05 {
             graph [goal="X"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             orphan [shape=box]
             done [shape=Msquare]
             start -> done
@@ -165,7 +165,7 @@ class TestValidationR06:
 
         g = Graph(
             name="R06",
-            nodes={"start": Node(id="start", shape="ellipse")},
+            nodes={"start": Node(id="start", shape="Mdiamond")},
             edges=[Edge(source="start", target="ghost")],
         )
         diags = validate(g)
@@ -181,7 +181,7 @@ class TestValidationR08:
         g = parse_dot("""
         digraph R08 {
             graph [goal="X"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             branch [shape=diamond]
             done [shape=Msquare]
             start -> branch -> done
@@ -196,7 +196,7 @@ class TestValidationR08:
         g = parse_dot("""
         digraph R08ok {
             graph [goal="X"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             branch [shape=diamond]
             a [shape=box]
             b [shape=box]
@@ -220,7 +220,7 @@ class TestValidationR09:
         g = parse_dot("""
         digraph R09 {
             graph [goal="X"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             done [shape=Msquare, goal_gate="outcome = success"]
             start -> done
         }
@@ -234,7 +234,7 @@ class TestValidationR09:
         g = parse_dot("""
         digraph R09ok {
             graph [goal="X"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             task [shape=box]
             done [shape=Msquare, goal_gate="outcome = success", retry_target="task"]
             start -> task -> done

--- a/tests/test_manager_middleware.py
+++ b/tests/test_manager_middleware.py
@@ -51,7 +51,7 @@ class TestManagerHandler:
         child_file = tmp_path / "child.dot"
         child_file.write_text(
             "digraph Child {\n"
-            "  start [shape=ellipse]\n"
+            "  start [shape=Mdiamond]\n"
             "  task [shape=box]\n"
             "  done [shape=Msquare]\n"
             "  start -> task -> done\n"
@@ -62,7 +62,7 @@ class TestManagerHandler:
             name="Supervised",
             goal="File test",
             nodes={
-                "start": Node(id="start", shape="ellipse"),
+                "start": Node(id="start", shape="Mdiamond"),
                 "mgr": Node(
                     id="mgr",
                     shape="hexagon",
@@ -103,13 +103,13 @@ class TestManagerHandler:
         """Abort signal stops the manager loop."""
         child_file = tmp_path / "child.dot"
         child_file.write_text(
-            "digraph C { start [shape=ellipse]; done [shape=Msquare]; start -> done }\n"
+            "digraph C { start [shape=Mdiamond]; done [shape=Msquare]; start -> done }\n"
         )
 
         g = Graph(
             name="Abort",
             nodes={
-                "start": Node(id="start", shape="ellipse"),
+                "start": Node(id="start", shape="Mdiamond"),
                 "mgr": Node(
                     id="mgr",
                     shape="hexagon",
@@ -137,14 +137,14 @@ class TestManagerHandler:
         """Manager stores iteration metadata in context."""
         child_file = tmp_path / "child.dot"
         child_file.write_text(
-            "digraph C { start [shape=ellipse]; done [shape=Msquare]; start -> done }\n"
+            "digraph C { start [shape=Mdiamond]; done [shape=Msquare]; start -> done }\n"
         )
 
         g = Graph(
             name="Meta",
             goal="Metadata test",
             nodes={
-                "start": Node(id="start", shape="ellipse"),
+                "start": Node(id="start", shape="Mdiamond"),
                 "mgr": Node(
                     id="mgr",
                     shape="hexagon",
@@ -181,7 +181,7 @@ class TestManagerHandler:
             name="MaxIter",
             goal="Max iterations",
             nodes={
-                "start": Node(id="start", shape="ellipse"),
+                "start": Node(id="start", shape="Mdiamond"),
                 "mgr": Node(
                     id="mgr",
                     shape="hexagon",

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -561,7 +561,7 @@ class TestSubagentSpawning:
 
         req = adapter.requests[0]
         tool_names = [t.name for t in (req.tools or [])]
-        assert "delegate" in tool_names
+        assert "spawn_agent" in tool_names
 
     @pytest.mark.asyncio
     async def test_subagent_no_delegate_tool_at_max_depth_minus_one(self):
@@ -583,7 +583,7 @@ class TestSubagentSpawning:
         req = adapter.requests[0]
         tool_names = [t.name for t in (req.tools or [])]
         # Child depth is 3, max_depth is 3 -> can't delegate further
-        assert "delegate" not in tool_names
+        assert "spawn_agent" not in tool_names
 
     @pytest.mark.asyncio
     async def test_usage_tracked(self):

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -36,7 +36,7 @@ class TestExecuteSubgraph:
         """Subgraph runs through linear nodes and stops at fan-in boundary."""
         g = parse_dot("""
         digraph Sub {
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             a [shape=box, prompt="Task A"]
             b [shape=box, prompt="Task B"]
             join [shape=tripleoctagon]
@@ -271,7 +271,7 @@ class TestParallelPipeline:
         g = parse_dot("""
         digraph Parallel {
             graph [goal="Parallel test"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             fork [shape=component]
             branch_a [shape=box, prompt="Branch A"]
             branch_b [shape=box, prompt="Branch B"]
@@ -301,7 +301,7 @@ class TestParallelPipeline:
         g = parse_dot("""
         digraph ParaTool {
             graph [goal="Parallel tools"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             fork [shape=component]
             cmd_a [shape=parallelogram, prompt="echo branch_a_output"]
             cmd_b [shape=parallelogram, prompt="echo branch_b_output"]
@@ -335,7 +335,7 @@ class TestParallelPipeline:
         """Aborting during parallel execution cancels all branches."""
         g = parse_dot("""
         digraph ParaAbort {
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             fork [shape=component]
             a [shape=box, prompt="A"]
             b [shape=box, prompt="B"]
@@ -364,7 +364,7 @@ class TestParallelPipeline:
         g = parse_dot("""
         digraph Single {
             graph [goal="Single branch"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             fork [shape=component]
             only [shape=box, prompt="Only branch"]
             join [shape=tripleoctagon]
@@ -387,7 +387,7 @@ class TestParallelPipeline:
         g = parse_dot("""
         digraph NoEdge {
             graph [goal="No edges"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             fork [shape=component]
             done [shape=Msquare]
             start -> fork -> done
@@ -407,7 +407,7 @@ class TestParallelPipeline:
         g = parse_dot("""
         digraph NonPara {
             graph [goal="Non-parallel"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             task [shape=box, prompt="Task"]
             join [shape=tripleoctagon]
             done [shape=Msquare]
@@ -427,7 +427,7 @@ class TestParallelPipeline:
         g = parse_dot("""
         digraph CtxIso {
             graph [goal="Context isolation"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             fork [shape=component]
             a [shape=parallelogram, prompt="echo alpha"]
             b [shape=parallelogram, prompt="echo beta"]
@@ -458,7 +458,7 @@ class TestParallelPipeline:
         g = parse_dot("""
         digraph ThreeWay {
             graph [goal="Three-way"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             fork [shape=component]
             a [shape=box, prompt="A"]
             b [shape=box, prompt="B"]
@@ -501,7 +501,7 @@ class TestParallelEdgeCases:
         g = parse_dot("""
         digraph Mixed {
             graph [goal="Mixed"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             fork [shape=component]
             good [shape=box, prompt="Good"]
             bad [shape=box, handler="nonexistent"]
@@ -528,7 +528,7 @@ class TestParallelEdgeCases:
         g = parse_dot("""
         digraph Ckpt {
             graph [goal="Checkpoint"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             fork [shape=component]
             a [shape=box, prompt="A"]
             b [shape=box, prompt="B"]

--- a/tests/test_partial_items_fixes.py
+++ b/tests/test_partial_items_fixes.py
@@ -146,7 +146,7 @@ class TestVariableExpansionNoMutation:
 
         graph = Graph(name="test")
         graph.nodes["start"] = Node(
-            id="start", shape="ellipse", label="Start", prompt="Goal is $goal"
+            id="start", shape="Mdiamond", label="Start", prompt="Goal is $goal"
         )
         graph.nodes["end"] = Node(id="end", shape="Msquare", label="End")
         graph.edges.append(Edge(source="start", target="end"))
@@ -169,7 +169,7 @@ class TestVariableExpansionNoMutation:
         from attractor_pipeline.transforms import VariableExpansionTransform
 
         graph = Graph(name="test")
-        graph.nodes["a"] = Node(id="a", shape="ellipse", prompt="$x")
+        graph.nodes["a"] = Node(id="a", shape="Mdiamond", prompt="$x")
         graph.edges.append(Edge(source="a", target="a"))
 
         transform = VariableExpansionTransform({"x": "val"})

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -28,7 +28,7 @@ async def run_tests() -> None:
     g = parse_dot("""
     digraph Simple {
         graph [goal="Test pipeline"]
-        start [shape=ellipse]
+        start [shape=Mdiamond]
         task [shape=box, prompt="Do something"]
         done [shape=Msquare]
         start -> task -> done
@@ -49,7 +49,7 @@ async def run_tests() -> None:
     g2 = parse_dot("""
     digraph Branch {
         graph [goal="Test branching"]
-        start [shape=ellipse]
+        start [shape=Mdiamond]
         check [shape=diamond]
         yes_path [shape=box, prompt="Yes path"]
         no_path [shape=box, prompt="No path"]
@@ -75,7 +75,7 @@ async def run_tests() -> None:
     g3 = parse_dot("""
     digraph GoalGate {
         graph [goal="Pass the gate", max_goal_gate_redirects="2"]
-        start [shape=ellipse]
+        start [shape=Mdiamond]
         code [shape=box, prompt="Write code"]
         done [shape=Msquare, goal_gate="outcome = fail", retry_target="code"]
         start -> code -> done
@@ -96,7 +96,7 @@ async def run_tests() -> None:
 
     g4 = parse_dot("""
     digraph Abort {
-        start [shape=ellipse]
+        start [shape=Mdiamond]
         done [shape=Msquare]
         start -> done
     }
@@ -116,7 +116,7 @@ async def run_tests() -> None:
     g5 = parse_dot("""
     digraph Checkpoint {
         graph [goal="Test checkpoint"]
-        start [shape=ellipse]
+        start [shape=Mdiamond]
         task1 [shape=box, prompt="Task 1"]
         task2 [shape=box, prompt="Task 2"]
         done [shape=Msquare]
@@ -180,7 +180,7 @@ async def run_tests() -> None:
     # === Test 8: Tool handler ===
     g8 = parse_dot("""
     digraph ToolTest {
-        start [shape=ellipse]
+        start [shape=Mdiamond]
         run [shape=parallelogram, prompt="echo hello_from_pipeline"]
         done [shape=Msquare]
         start -> run -> done
@@ -198,7 +198,7 @@ async def run_tests() -> None:
     # === Test 9: Human handler (auto-approve) ===
     g9 = parse_dot("""
     digraph HumanGate {
-        start [shape=ellipse]
+        start [shape=Mdiamond]
         approve [shape=house, prompt="Deploy to production?"]
         deploy [shape=box, prompt="Deploying"]
         done [shape=Msquare]
@@ -220,7 +220,7 @@ async def run_tests() -> None:
     # === Test 10: Missing handler fails gracefully ===
     g10 = parse_dot("""
     digraph Missing {
-        start [shape=ellipse]
+        start [shape=Mdiamond]
         custom [shape=box, handler="nonexistent_handler"]
         done [shape=Msquare]
         start -> custom -> done
@@ -243,7 +243,7 @@ async def run_tests() -> None:
     g11 = parse_dot("""
     digraph Codergen {
         graph [goal="Build feature"]
-        start [shape=ellipse]
+        start [shape=Mdiamond]
         code [shape=box, prompt="Implement $goal"]
         done [shape=Msquare]
         start -> code -> done

--- a/tests/test_pipeline_engine.py
+++ b/tests/test_pipeline_engine.py
@@ -38,7 +38,7 @@ class TestDotParser:
         g = parse_dot("""
         digraph Simple {
             graph [goal="Test"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             task [shape=box]
             done [shape=Msquare]
             start -> task -> done
@@ -51,7 +51,7 @@ class TestDotParser:
     def test_chained_edges_expand(self):
         g = parse_dot("""
         digraph Chain {
-            a [shape=ellipse]
+            a [shape=Mdiamond]
             b [shape=box]
             c [shape=box]
             d [shape=Msquare]
@@ -66,7 +66,7 @@ class TestDotParser:
     def test_edge_attributes(self):
         g = parse_dot("""
         digraph Attrs {
-            a [shape=ellipse]
+            a [shape=Mdiamond]
             b [shape=box]
             a -> b [label="yes", condition="outcome = success", weight="2.0"]
         }
@@ -106,7 +106,7 @@ class TestDotParser:
         // line comment
         digraph Comments {
             /* block comment */
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             done [shape=Msquare]
             start -> done
         }
@@ -117,7 +117,7 @@ class TestDotParser:
         g = parse_dot("""
         digraph Config {
             graph [goal="X", default_max_retry="10", max_goal_gate_redirects="3"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
         }
         """)
         assert g.goal == "X"
@@ -130,7 +130,7 @@ class TestDotParser:
 
     def test_start_node_lookup(self):
         g = parse_dot("""
-        digraph S { start [shape=ellipse]; done [shape=Msquare]; start -> done }
+        digraph S { start [shape=Mdiamond]; done [shape=Msquare]; start -> done }
         """)
         assert g.get_start_node() is not None
         assert g.get_start_node().id == "start"
@@ -138,7 +138,7 @@ class TestDotParser:
     def test_exit_nodes_lookup(self):
         g = parse_dot("""
         digraph E {
-            s [shape=ellipse]
+            s [shape=Mdiamond]
             d1 [shape=Msquare]
             d2 [shape=Msquare]
             s -> d1; s -> d2
@@ -242,7 +242,7 @@ class TestPipelineExecution:
         g = parse_dot("""
         digraph L {
             graph [goal="Test"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             task [shape=box, prompt="Hello"]
             done [shape=Msquare]
             start -> task -> done
@@ -261,7 +261,7 @@ class TestPipelineExecution:
         g = parse_dot("""
         digraph B {
             graph [goal="Branch"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             check [shape=diamond]
             yes [shape=box, prompt="Y"]
             no [shape=box, prompt="N"]
@@ -285,7 +285,7 @@ class TestPipelineExecution:
         g = parse_dot("""
         digraph G {
             graph [goal="Gate", max_goal_gate_redirects="2"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             code [shape=box, prompt="Code"]
             done [shape=Msquare, goal_gate="outcome = fail", retry_target="code"]
             start -> code -> done
@@ -302,7 +302,7 @@ class TestPipelineExecution:
     async def test_abort_cancels_pipeline(self):
         g = parse_dot("""
         digraph A {
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             done [shape=Msquare]
             start -> done
         }
@@ -321,7 +321,7 @@ class TestPipelineExecution:
         g = parse_dot("""
         digraph C {
             graph [goal="Checkpoint"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             t1 [shape=box, prompt="T1"]
             done [shape=Msquare]
             start -> t1 -> done
@@ -342,7 +342,7 @@ class TestPipelineExecution:
     async def test_tool_handler_executes_command(self):
         g = parse_dot("""
         digraph T {
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             run [shape=parallelogram, prompt="echo hello_pipeline"]
             done [shape=Msquare]
             start -> run -> done
@@ -359,7 +359,7 @@ class TestPipelineExecution:
     async def test_human_handler_auto_approve(self):
         g = parse_dot("""
         digraph H {
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             gate [shape=house, prompt="Approve?"]
             task [shape=box, prompt="Do it"]
             done [shape=Msquare]
@@ -379,7 +379,7 @@ class TestPipelineExecution:
     async def test_missing_handler_fails(self):
         g = parse_dot("""
         digraph M {
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             custom [shape=box, handler="nonexistent"]
             done [shape=Msquare]
             start -> custom -> done
@@ -401,7 +401,7 @@ class TestPipelineExecution:
         g = parse_dot("""
         digraph CB {
             graph [goal="Build feature"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             code [shape=box, prompt="Implement $goal"]
             done [shape=Msquare]
             start -> code -> done
@@ -426,7 +426,7 @@ class TestPipelineExecution:
 class TestValidation:
     def test_valid_graph_passes(self):
         g = parse_dot("""
-        digraph V { graph [goal="X"]; start [shape=ellipse]; done [shape=Msquare]; start -> done }
+        digraph V { graph [goal="X"]; start [shape=Mdiamond]; done [shape=Msquare]; start -> done }
         """)
         diags = validate(g)
         errors = [d for d in diags if d.severity == Severity.ERROR]
@@ -442,7 +442,7 @@ class TestValidation:
 
     def test_missing_exit_node(self):
         g = parse_dot("""
-        digraph NoExit { start [shape=ellipse]; task [shape=box]; start -> task }
+        digraph NoExit { start [shape=Mdiamond]; task [shape=box]; start -> task }
         """)
         diags = validate(g)
         r02 = [d for d in diags if d.rule == "R02"]
@@ -450,7 +450,7 @@ class TestValidation:
 
     def test_exit_unreachable(self):
         g = parse_dot("""
-        digraph Unreach { start [shape=ellipse]; a [shape=box]; done [shape=Msquare]; start -> a }
+        digraph Unreach { start [shape=Mdiamond]; a [shape=box]; done [shape=Msquare]; start -> a }
         """)
         diags = validate(g)
         r07 = [d for d in diags if d.rule == "R07"]
@@ -465,7 +465,7 @@ class TestValidation:
         g = parse_dot("""
         digraph BadRetry {
             graph [goal="X"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             done [shape=Msquare, goal_gate="outcome = success", retry_target="ghost"]
             start -> done
         }
@@ -478,7 +478,7 @@ class TestValidation:
         g = parse_dot("""
         digraph Loop {
             graph [goal="X"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             task [shape=box]
             done [shape=Msquare]
             start -> task -> done
@@ -491,7 +491,7 @@ class TestValidation:
 
     def test_no_goal_info(self):
         g = parse_dot("""
-        digraph NoGoal { start [shape=ellipse]; done [shape=Msquare]; start -> done }
+        digraph NoGoal { start [shape=Mdiamond]; done [shape=Msquare]; start -> done }
         """)
         diags = validate(g)
         r12 = [d for d in diags if d.rule == "R12"]
@@ -532,7 +532,7 @@ class TestStylesheet:
         g = parse_dot("""
         digraph S {
             graph [model_stylesheet="* { llm_model: base; }\nbox { llm_model: shape; }\n.special { llm_model: class; }\n#node1 { llm_model: id; }"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             node1 [shape=box, class="special"]
             node2 [shape=box, class="special"]
             node3 [shape=box]
@@ -550,7 +550,7 @@ class TestStylesheet:
         g = parse_dot("""
         digraph O {
             graph [model_stylesheet="* { llm_model: stylesheet; }"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             explicit [shape=box, llm_model="from-dot"]
             implicit [shape=box]
             done [shape=Msquare]

--- a/tests/test_preamble.py
+++ b/tests/test_preamble.py
@@ -36,7 +36,7 @@ def make_test_graph() -> Graph:
         name="TestPipeline",
         goal="Build a widget",
         nodes={
-            "start": Node(id="start", shape="ellipse"),
+            "start": Node(id="start", shape="Mdiamond"),
             "plan": Node(id="plan", shape="box", prompt="Plan: $goal"),
             "implement": Node(id="implement", shape="box", prompt="Implement: $goal"),
             "done": Node(id="done", shape="Msquare"),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -26,7 +26,7 @@ from attractor_server.sse import format_sse_event
 SIMPLE_DOT = """
 digraph Simple {
     graph [goal="Test pipeline"]
-    start [shape=ellipse]
+    start [shape=Mdiamond]
     task [shape=box, prompt="Hello"]
     done [shape=Msquare]
     start -> task -> done
@@ -323,7 +323,7 @@ class TestPipelineManager:
         long_dot = """
         digraph Long {
             graph [goal="Long task"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             a [shape=box, prompt="Step A"]
             b [shape=box, prompt="Step B"]
             c [shape=box, prompt="Step C"]
@@ -374,7 +374,7 @@ class TestSSESubscriber:
 
         run = PipelineRun(
             id="test",
-            graph=Graph(name="Test", nodes={"s": Node(id="s", shape="ellipse")}),
+            graph=Graph(name="Test", nodes={"s": Node(id="s", shape="Mdiamond")}),
         )
         queue = run.subscribe()
         run.emit("test.event", {"key": "value"})
@@ -390,7 +390,7 @@ class TestSSESubscriber:
 
         run = PipelineRun(
             id="test",
-            graph=Graph(name="Test", nodes={"s": Node(id="s", shape="ellipse")}),
+            graph=Graph(name="Test", nodes={"s": Node(id="s", shape="Mdiamond")}),
         )
         queue = run.subscribe()
         run.close_subscribers()
@@ -404,7 +404,7 @@ class TestSSESubscriber:
 
         run = PipelineRun(
             id="test",
-            graph=Graph(name="Test", nodes={"s": Node(id="s", shape="ellipse")}),
+            graph=Graph(name="Test", nodes={"s": Node(id="s", shape="Mdiamond")}),
         )
         queue = run.subscribe()
         run.unsubscribe(queue)
@@ -423,7 +423,7 @@ class TestWebInterviewer:
 
         run = PipelineRun(
             id="test",
-            graph=Graph(name="Test", nodes={"s": Node(id="s", shape="ellipse")}),
+            graph=Graph(name="Test", nodes={"s": Node(id="s", shape="Mdiamond")}),
         )
         interviewer = WebInterviewer(run, timeout=5.0)
 
@@ -450,7 +450,7 @@ class TestWebInterviewer:
 
         run = PipelineRun(
             id="test",
-            graph=Graph(name="Test", nodes={"s": Node(id="s", shape="ellipse")}),
+            graph=Graph(name="Test", nodes={"s": Node(id="s", shape="Mdiamond")}),
         )
         interviewer = WebInterviewer(run, timeout=0.1)
 
@@ -463,6 +463,6 @@ class TestWebInterviewer:
 
         run = PipelineRun(
             id="test",
-            graph=Graph(name="Test", nodes={"s": Node(id="s", shape="ellipse")}),
+            graph=Graph(name="Test", nodes={"s": Node(id="s", shape="Mdiamond")}),
         )
         assert submit_answer(run, "nonexistent", "yes") is False

--- a/tests/test_wave1_spec_compliance.py
+++ b/tests/test_wave1_spec_compliance.py
@@ -495,7 +495,7 @@ class TestValidationConditionSyntax:
     def test_valid_condition_no_diagnostic(self):
         """A valid condition expression should produce no R14 diagnostic."""
         graph = Graph(name="test")
-        graph.nodes["start"] = Node(id="start", shape="ellipse")
+        graph.nodes["start"] = Node(id="start", shape="Mdiamond")
         graph.nodes["a"] = Node(id="a", shape="box", prompt="do stuff")
         graph.nodes["b"] = Node(id="b", shape="box", prompt="other stuff")
         graph.nodes["exit"] = Node(id="exit", shape="Msquare")
@@ -511,7 +511,7 @@ class TestValidationConditionSyntax:
     def test_invalid_condition_produces_error(self):
         """An edge with an unparseable condition produces an ERROR diagnostic."""
         graph = Graph(name="test")
-        graph.nodes["start"] = Node(id="start", shape="ellipse")
+        graph.nodes["start"] = Node(id="start", shape="Mdiamond")
         graph.nodes["a"] = Node(id="a", shape="box", prompt="do stuff")
         graph.nodes["b"] = Node(id="b", shape="box", prompt="other stuff")
         graph.nodes["exit"] = Node(id="exit", shape="Msquare")
@@ -535,7 +535,7 @@ class TestValidationPromptOnLlmNodes:
     def test_box_node_without_prompt_produces_warning(self):
         """An LLM node (box) with no prompt and no label produces a WARNING."""
         graph = Graph(name="test")
-        graph.nodes["start"] = Node(id="start", shape="ellipse")
+        graph.nodes["start"] = Node(id="start", shape="Mdiamond")
         # Box node with no prompt and no label
         graph.nodes["work"] = Node(id="work", shape="box")
         graph.nodes["exit"] = Node(id="exit", shape="Msquare")
@@ -553,7 +553,7 @@ class TestValidationPromptOnLlmNodes:
     def test_box_node_with_prompt_no_warning(self):
         """An LLM node with a prompt should NOT trigger a warning."""
         graph = Graph(name="test")
-        graph.nodes["start"] = Node(id="start", shape="ellipse")
+        graph.nodes["start"] = Node(id="start", shape="Mdiamond")
         graph.nodes["work"] = Node(id="work", shape="box", prompt="Write some code")
         graph.nodes["exit"] = Node(id="exit", shape="Msquare")
         graph.edges.append(Edge(source="start", target="work"))
@@ -567,7 +567,7 @@ class TestValidationPromptOnLlmNodes:
     def test_box_node_with_label_no_warning(self):
         """An LLM node with a label (but no prompt) should NOT trigger a warning."""
         graph = Graph(name="test")
-        graph.nodes["start"] = Node(id="start", shape="ellipse")
+        graph.nodes["start"] = Node(id="start", shape="Mdiamond")
         graph.nodes["work"] = Node(id="work", shape="box", label="Code Review")
         graph.nodes["exit"] = Node(id="exit", shape="Msquare")
         graph.edges.append(Edge(source="start", target="work"))
@@ -581,7 +581,7 @@ class TestValidationPromptOnLlmNodes:
     def test_non_box_node_without_prompt_no_warning(self):
         """Non-box shapes (diamond, etc.) don't require prompts."""
         graph = Graph(name="test")
-        graph.nodes["start"] = Node(id="start", shape="ellipse")
+        graph.nodes["start"] = Node(id="start", shape="Mdiamond")
         graph.nodes["branch"] = Node(id="branch", shape="diamond")
         graph.nodes["exit"] = Node(id="exit", shape="Msquare")
         graph.edges.append(Edge(source="start", target="branch"))

--- a/tests/test_wave3_event_truncation_steering.py
+++ b/tests/test_wave3_event_truncation_steering.py
@@ -394,7 +394,7 @@ class TestTruncationOrdering:
 
         assert was_truncated is True
         assert len(result) < len(output)
-        assert "characters omitted" in result
+        assert "characters were removed from the middle" in result
 
     def test_lines_truncated_after_chars(self):
         """Line truncation operates on the already char-truncated output."""
@@ -406,7 +406,7 @@ class TestTruncationOrdering:
         result, was_truncated = truncate_output(output, limits)
 
         assert was_truncated is True
-        assert "lines omitted" in result
+        assert "lines were removed from the middle" in result
 
     def test_both_passes_can_trigger(self):
         """Both char and line truncation can trigger in sequence.
@@ -422,10 +422,12 @@ class TestTruncationOrdering:
         result, was_truncated = truncate_output(output, limits)
 
         assert was_truncated is True
-        # Line count bounded by max_lines (+ a few for omission markers)
-        assert len(result.split("\n")) <= 20 + 4
-        # Char count well under original (both passes ran)
-        assert len(result) < 10_000
+        # Line count bounded by max_lines (+ a few for omission markers and
+        # the longer WARNING text which may wrap across multiple lines)
+        assert len(result.split("\n")) <= 20 + 10
+        # Char count well under original (both passes ran); the WARNING
+        # marker text adds overhead so we allow up to 11k
+        assert len(result) < 11_000
 
     def test_no_truncation_when_within_limits(self):
         result, was_truncated = truncate_output("short", TruncationLimits())

--- a/tests/test_wave4_pipeline_fixes.py
+++ b/tests/test_wave4_pipeline_fixes.py
@@ -65,7 +65,7 @@ class TestPerNodeArtifacts:
         g = parse_dot("""
         digraph S {
             graph [goal="Test"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             done [shape=Msquare]
             start -> done
         }
@@ -91,7 +91,7 @@ class TestPerNodeArtifacts:
         g = parse_dot("""
         digraph E {
             graph [goal="Test"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             done [shape=Msquare]
             start -> done
         }
@@ -117,7 +117,7 @@ class TestPerNodeArtifacts:
         g = parse_dot("""
         digraph C {
             graph [goal="Build widget"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             code [shape=box, prompt="Implement $goal"]
             done [shape=Msquare]
             start -> code -> done
@@ -152,7 +152,7 @@ class TestPerNodeArtifacts:
         g = parse_dot("""
         digraph D {
             graph [goal="Branch"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             check [shape=diamond]
             done [shape=Msquare]
             start -> check -> done
@@ -174,7 +174,7 @@ class TestPerNodeArtifacts:
         g = parse_dot("""
         digraph T {
             graph [goal="Run tool"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             run [shape=parallelogram, prompt="echo hello_artifact"]
             done [shape=Msquare]
             start -> run -> done
@@ -205,7 +205,7 @@ class TestPerNodeArtifacts:
         g = parse_dot("""
         digraph N {
             graph [goal="Test"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             code [shape=box, prompt="Do something"]
             done [shape=Msquare]
             start -> code -> done
@@ -225,7 +225,7 @@ class TestPerNodeArtifacts:
         g = parse_dot("""
         digraph Multi {
             graph [goal="Multi-step"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             step1 [shape=box, prompt="Step 1"]
             step2 [shape=box, prompt="Step 2"]
             done [shape=Msquare]
@@ -262,7 +262,7 @@ class TestAggregateGoalGate:
         g = parse_dot("""
         digraph G {
             graph [goal="Gate test", max_goal_gate_redirects="2"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             code [shape=box, prompt="Code", goal_gate="outcome = fail", retry_target="code"]
             done [shape=Msquare]
             start -> code -> done
@@ -286,7 +286,7 @@ class TestAggregateGoalGate:
         g = parse_dot("""
         digraph G {
             graph [goal="Gate OK"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             code [shape=box, prompt="Code", goal_gate="outcome = success"]
             done [shape=Msquare]
             start -> code -> done
@@ -306,7 +306,7 @@ class TestAggregateGoalGate:
         g = parse_dot("""
         digraph G {
             graph [goal="Unvisited"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             check [shape=diamond]
             code [shape=box, prompt="Code"]
             other_code [shape=box, prompt="Other", goal_gate="outcome = fail", retry_target="other_code"]
@@ -344,7 +344,7 @@ class TestAggregateGoalGate:
         g = parse_dot("""
         digraph G {
             graph [goal="Retry", max_goal_gate_redirects="3"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             code [shape=box, prompt="Code", goal_gate="outcome = fail", retry_target="retry_node"]
             retry_node [shape=box, prompt="Retry"]
             done [shape=Msquare]
@@ -370,7 +370,7 @@ class TestAggregateGoalGate:
         g = parse_dot("""
         digraph G {
             graph [goal="Multi-gate", max_goal_gate_redirects="2"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             gate1 [shape=box, prompt="G1", goal_gate="outcome = success"]
             gate2 [shape=box, prompt="G2", goal_gate="outcome = success"]
             done [shape=Msquare]
@@ -392,7 +392,7 @@ class TestAggregateGoalGate:
         g = parse_dot("""
         digraph G {
             graph [goal="Multi-gate fail", max_goal_gate_redirects="2"]
-            start [shape=ellipse]
+            start [shape=Mdiamond]
             gate1 [shape=box, prompt="G1", goal_gate="outcome = success"]
             gate2 [shape=box, prompt="G2", goal_gate="outcome = fail", retry_target="gate2"]
             done [shape=Msquare]

--- a/tests/test_wave7_human_transforms.py
+++ b/tests/test_wave7_human_transforms.py
@@ -199,7 +199,7 @@ class TestQuestionType:
 def _make_graph(**kwargs: object) -> Graph:
     """Create a minimal valid graph for testing."""
     g = Graph(name="test")
-    g.nodes["start"] = Node(id="start", shape="ellipse", label="Start")
+    g.nodes["start"] = Node(id="start", shape="Mdiamond", label="Start")
     g.nodes["end"] = Node(id="end", shape="Msquare", label="End")
     g.edges.append(Edge(source="start", target="end"))
     for k, v in kwargs.items():


### PR DESCRIPTION
## Wave 9: Quick-Win Spec Compliance Fixes

10 fixes addressing gaps identified in the DoD spec compliance audit. Each fix targets a specific spec section with surgical changes.

### Changes

| # | Fix | Spec Section |
|---|-----|-------------|
| P8 | Anthropic `tool_choice=none` omits tools array | §8.7 |
| P14 | OpenAI profile wires `apply_patch` into tool set | §9.2 |
| P16 | Provider-specific identity in system prompts | §9.2 |
| P17 | Truncation markers use full spec warning text | §9.5 |
| P18 | Fixed truncation char limits for 5 tools | §9.5 |
| P20 | `user_instructions` field appended last in prompt | §9.8 |
| P21 | `spawn_agent` tool: wired `working_dir` param through to `SessionConfig` | §9.9 |
| P26/P27 | `start_no_incoming`/`exit_no_outgoing` severity → ERROR | §11.2 |
| F | Start node shape `ellipse` → `Mdiamond` throughout | §11.2 |

### P21 Detail: `working_dir` was dead code

`spawn_agent_execute()` accepted `working_dir` but never passed it to `spawn_subagent()`. Since `SessionConfig` has a `working_dir` field, the fix wires it through:
- Added `working_dir` param to `spawn_subagent()`
- Passes it to `SessionConfig(working_dir=working_dir)`
- `spawn_agent_execute()` now forwards it to `spawn_subagent()`

### Ellipse → Mdiamond Detail

Updated all 20 occurrences across:
- `README.md` (5 occurrences: shape table, examples, curl command)
- 15 `.dot` files in `examples/`
- `examples/e2e_test.py`

Left `docs/plans/` untouched (historical planning docs, not user-facing).

### Testing

```
731 passed in 7.80s
```

All mock tests pass. Ignored `test_e2e_integration.py` and `test_live_comprehensive.py` (require API keys).

### Review

Swarm-reviewed by Sonnet 4.5 + o3. Both issues (P21 dead code, stale ellipse refs) identified during swarm review and fixed in this commit.