### PR TITLE
fix: §11.11.5/9.4.1/9.8.2 — route aliases, env introspection, knowledge_cutoff

### DIFF
--- a/src/attractor_agent/environment.py
+++ b/src/attractor_agent/environment.py
@@ -110,6 +110,18 @@ class ExecutionEnvironment(Protocol):
         """List directory contents."""
         ...
 
+    async def working_directory(self) -> str:
+        """Return the current working directory."""
+        ...
+
+    def platform(self) -> str:
+        """Return the platform string (e.g. 'linux', 'darwin', 'windows')."""
+        ...
+
+    def os_version(self) -> str:
+        """Return the OS version string."""
+        ...
+
     async def start(self) -> None:
         """Initialize the environment (e.g., start container)."""
         ...
@@ -158,11 +170,13 @@ class LocalEnvironment:
     Behavior is identical to the pre-abstraction tool implementations.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, working_dir: str | None = None) -> None:
         # Callback invoked with the live subprocess.Popen right after spawn,
         # before communicate() blocks. Wired by Session.__init__ for abort tracking.
         # Spec §9.1.6, §9.11.5.
         self._spawn_callback: Any | None = None
+        # Optional working directory override for working_directory(). Spec §9.4.1.
+        self._working_dir: str | None = working_dir
 
     async def read_file(self, path: str) -> str:
         file_path = Path(path).expanduser().resolve()
@@ -264,6 +278,22 @@ class LocalEnvironment:
     async def list_dir(self, path: str) -> list[str]:
         p = Path(path).expanduser().resolve()
         return sorted(str(f.name) for f in p.iterdir())
+
+    async def working_directory(self) -> str:
+        """Return the current working directory of the host."""
+        return str(self._working_dir or Path.cwd())
+
+    def platform(self) -> str:
+        """Return the lowercase platform name (e.g. 'linux', 'darwin')."""
+        import sys
+
+        return sys.platform.lower()
+
+    def os_version(self) -> str:
+        """Return the OS version string from the platform module."""
+        import platform as _platform
+
+        return _platform.version()
 
     async def start(self) -> None:
         pass  # No-op for local
@@ -442,6 +472,19 @@ class DockerEnvironment:
         if result.returncode != 0:
             raise OSError(f"Failed to list {path}: {result.stderr}")
         return sorted(result.stdout.strip().split("\n")) if result.stdout.strip() else []
+
+    async def working_directory(self) -> str:
+        """Return the working directory inside the container."""
+        result = await self.exec_shell("pwd")
+        return result.stdout.strip()
+
+    def platform(self) -> str:
+        """Return 'docker' as the platform identifier."""
+        return "docker"
+
+    def os_version(self) -> str:
+        """Return 'docker' as the OS version placeholder."""
+        return "docker"
 
     def _check_running(self) -> None:
         if not self._container_id:

--- a/src/attractor_agent/session.py
+++ b/src/attractor_agent/session.py
@@ -789,11 +789,13 @@ class Session:
         if self._config.system_prompt:
             parts.append(self._config.system_prompt)
 
-        # 2. Environment context
-        # TODO: wire knowledge_cutoff from model metadata (catalog) when available
+        # 2. Environment context -- wire knowledge_cutoff from model catalog (Spec §9.8.2)
+        _model_info = get_model_info(self._config.model)
+        _knowledge_cutoff: str | None = _model_info.knowledge_cutoff if _model_info else None
         env_block = build_environment_context(
             working_dir=working_dir,
             model=self._config.model,
+            knowledge_cutoff=_knowledge_cutoff,
             git_info=git_info,
         )
         parts.append(env_block)

--- a/src/attractor_llm/catalog.py
+++ b/src/attractor_llm/catalog.py
@@ -24,6 +24,7 @@ class ModelInfo:
     input_cost_per_million: float | None = None
     output_cost_per_million: float | None = None
     aliases: tuple[str, ...] = ()
+    knowledge_cutoff: str | None = None
 
 
 MODEL_CATALOG: list[ModelInfo] = [
@@ -36,6 +37,7 @@ MODEL_CATALOG: list[ModelInfo] = [
         supports_vision=True,
         supports_reasoning=True,
         aliases=("opus", "claude-opus", "opus-4-6"),
+        knowledge_cutoff="2024-08",
     ),
     ModelInfo(
         id="claude-sonnet-4-5",
@@ -46,6 +48,7 @@ MODEL_CATALOG: list[ModelInfo] = [
         supports_vision=True,
         supports_reasoning=True,
         aliases=("sonnet", "claude-sonnet", "sonnet-4-5"),
+        knowledge_cutoff="2024-08",
     ),
     ModelInfo(
         id="gpt-5.2",
@@ -56,6 +59,7 @@ MODEL_CATALOG: list[ModelInfo] = [
         supports_vision=True,
         supports_reasoning=True,
         aliases=("gpt-5", "5.2"),
+        knowledge_cutoff="2024-04",
     ),
     ModelInfo(
         id="gpt-5.2-mini",
@@ -66,6 +70,7 @@ MODEL_CATALOG: list[ModelInfo] = [
         supports_vision=True,
         supports_reasoning=True,
         aliases=("gpt-mini", "5.2-mini"),
+        knowledge_cutoff="2024-04",
     ),
     ModelInfo(
         id="gpt-5.2-codex",
@@ -76,6 +81,7 @@ MODEL_CATALOG: list[ModelInfo] = [
         supports_vision=True,
         supports_reasoning=True,
         aliases=("gpt-codex", "5.2-codex"),
+        knowledge_cutoff="2024-04",
     ),
     ModelInfo(
         id="gemini-3-pro-preview",
@@ -86,6 +92,7 @@ MODEL_CATALOG: list[ModelInfo] = [
         supports_vision=True,
         supports_reasoning=True,
         aliases=("gemini-pro", "3-pro"),
+        knowledge_cutoff="2024-12",
     ),
     ModelInfo(
         id="gemini-3-flash-preview",
@@ -96,6 +103,7 @@ MODEL_CATALOG: list[ModelInfo] = [
         supports_vision=True,
         supports_reasoning=True,
         aliases=("gemini-flash", "3-flash", "flash"),
+        knowledge_cutoff="2024-12",
     ),
 ]
 

--- a/src/attractor_server/app.py
+++ b/src/attractor_server/app.py
@@ -1,6 +1,6 @@
-"""Starlette application with all 9 REST endpoints.
+"""Starlette application with all 9 REST endpoints plus DoD §11.11.5 aliases.
 
-Spec reference: attractor-spec §9.5.
+Spec reference: attractor-spec §9.5, §11.11.5.
 """
 
 from __future__ import annotations
@@ -302,6 +302,49 @@ async def get_context(request: Request) -> JSONResponse:
 
 
 # ------------------------------------------------------------------ #
+# DoD §11.11.5 alias: POST /answer/{id}
+# ------------------------------------------------------------------ #
+
+
+async def _answer_first_question(request: Request) -> JSONResponse:
+    """Submit an answer to the FIRST pending question in a pipeline.
+
+    Simplified alias for POST /pipelines/{id}/questions/{qid}/answer that
+    does not require knowing the question ID in advance.  Accepts
+    ``{"answer": "..."}`` and applies it to the first pending question.
+    """
+    manager = get_manager()
+    pipeline_id = request.path_params["id"]
+    run = manager.get_run(pipeline_id)
+
+    if not run:
+        return JSONResponse({"error": f"Pipeline {pipeline_id} not found"}, status_code=404)
+
+    if not run.pending_questions:
+        return JSONResponse({"error": "No pending questions for this pipeline"}, status_code=404)
+
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    answer = body.get("answer")
+    if not answer:
+        return JSONResponse({"error": "Missing 'answer' field"}, status_code=400)
+
+    # Take the first pending question (ordered by insertion)
+    first_qid = next(iter(run.pending_questions))
+    accepted = submit_answer(run, first_qid, answer)
+    if not accepted:
+        return JSONResponse(
+            {"error": f"Question {first_qid} could not be answered"},
+            status_code=404,
+        )
+
+    return JSONResponse({"qid": first_qid, "accepted": True})
+
+
+# ------------------------------------------------------------------ #
 # App factory
 # ------------------------------------------------------------------ #
 
@@ -309,7 +352,7 @@ async def get_context(request: Request) -> JSONResponse:
 def create_app(
     manager: PipelineManager | None = None,
 ) -> Starlette:
-    """Create the Starlette application with all 9 endpoints."""
+    """Create the Starlette application with all 9 endpoints plus DoD §11.11.5 aliases."""
     global _manager  # noqa: PLW0603
     _manager = manager or PipelineManager()
 
@@ -327,6 +370,10 @@ def create_app(
         ),
         Route("/pipelines/{id}/checkpoint", get_checkpoint, methods=["GET"]),
         Route("/pipelines/{id}/context", get_context, methods=["GET"]),
+        # DoD §11.11.5 aliases
+        Route("/run", start_pipeline, methods=["POST"]),
+        Route("/status/{id}", get_pipeline, methods=["GET"]),
+        Route("/answer/{id}", _answer_first_question, methods=["POST"]),
     ]
 
     app = Starlette(routes=routes)

--- a/tests/test_dod_gaps.py
+++ b/tests/test_dod_gaps.py
@@ -1951,3 +1951,180 @@ class TestToolHandlerToolCommand:
             result = await handler.execute(node, ctx, graph, None, None)
 
         assert result.status == Outcome.SUCCESS
+
+# §11.11.5: DoD alias routes -- GET /status/{id}
+# ================================================================== #
+
+
+class TestDoDRouteAliases:
+    """§11.11.5: HTTP server must expose /run, /status/{id}, /answer/{id} aliases."""
+
+    def test_status_alias_returns_404_for_unknown_pipeline(self):
+        """GET /status/{id} returns 404 when the pipeline does not exist."""
+        from starlette.testclient import TestClient
+
+        from attractor_server.app import create_app
+        from attractor_server.pipeline_manager import PipelineManager
+
+        app = create_app(manager=PipelineManager())
+        client = TestClient(app, raise_server_exceptions=True)
+
+        response = client.get("/status/nonexistent-pipeline-id")
+        assert response.status_code == 404
+        assert "not found" in response.json().get("error", "").lower()
+
+    def test_run_alias_exists(self):
+        """POST /run is wired; a bad-body request returns 400 (not 404/405)."""
+        from starlette.testclient import TestClient
+
+        from attractor_server.app import create_app
+        from attractor_server.pipeline_manager import PipelineManager
+
+        app = create_app(manager=PipelineManager())
+        client = TestClient(app, raise_server_exceptions=True)
+
+        response = client.post("/run", json={})  # missing dot_source
+        assert response.status_code == 400
+
+    def test_answer_alias_returns_404_for_unknown_pipeline(self):
+        """POST /answer/{id} returns 404 when the pipeline does not exist."""
+        from starlette.testclient import TestClient
+
+        from attractor_server.app import create_app
+        from attractor_server.pipeline_manager import PipelineManager
+
+        app = create_app(manager=PipelineManager())
+        client = TestClient(app, raise_server_exceptions=True)
+
+        response = client.post("/answer/no-such-id", json={"answer": "yes"})
+        assert response.status_code == 404
+
+
+# ================================================================== #
+# §9.4.1: ExecutionEnvironment.platform() / working_directory()
+# ================================================================== #
+
+
+class TestExecutionEnvironmentIntrospection:
+    """§9.4.1: LocalEnvironment must expose platform(), os_version(), working_directory()."""
+
+    def test_platform_returns_non_empty_string(self):
+        """LocalEnvironment.platform() returns a non-empty string."""
+        from attractor_agent.environment import LocalEnvironment
+
+        env = LocalEnvironment()
+        result = env.platform()
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_os_version_returns_non_empty_string(self):
+        """LocalEnvironment.os_version() returns a non-empty string."""
+        from attractor_agent.environment import LocalEnvironment
+
+        env = LocalEnvironment()
+        result = env.os_version()
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_working_directory_returns_current_directory(self):
+        """LocalEnvironment.working_directory() returns the current working directory."""
+        import os
+
+        from attractor_agent.environment import LocalEnvironment
+
+        env = LocalEnvironment()
+        result = await env.working_directory()
+        assert isinstance(result, str)
+        assert len(result) > 0
+        # Must match os.getcwd() when no working_dir override is set
+        assert result == os.getcwd()
+
+    @pytest.mark.asyncio
+    async def test_working_directory_honours_override(self):
+        """When working_dir is supplied, working_directory() returns that path."""
+        import tempfile
+
+        from attractor_agent.environment import LocalEnvironment
+
+        with tempfile.TemporaryDirectory() as tmp:
+            env = LocalEnvironment(working_dir=tmp)
+            result = await env.working_directory()
+            assert result == tmp
+
+
+# ================================================================== #
+# §9.8.2: knowledge_cutoff wired from ModelInfo through env block
+# ================================================================== #
+
+
+class TestKnowledgeCutoffWiring:
+    """§9.8.2: ModelInfo.knowledge_cutoff is populated and surfaced in the env block."""
+
+    def test_model_info_has_knowledge_cutoff_field(self):
+        """ModelInfo dataclass must have a knowledge_cutoff attribute."""
+        from attractor_llm.catalog import ModelInfo
+
+        info = ModelInfo(
+            id="test-model",
+            provider="test",
+            display_name="Test",
+            context_window=8192,
+            knowledge_cutoff="2024-08",
+        )
+        assert info.knowledge_cutoff == "2024-08"
+
+    def test_model_info_knowledge_cutoff_defaults_to_none(self):
+        """knowledge_cutoff defaults to None for models where it is not set."""
+        from attractor_llm.catalog import ModelInfo
+
+        info = ModelInfo(
+            id="test-model",
+            provider="test",
+            display_name="Test",
+            context_window=8192,
+        )
+        assert info.knowledge_cutoff is None
+
+    def test_catalog_models_have_knowledge_cutoff(self):
+        """All catalog models with known cutoffs should have the field populated."""
+        from attractor_llm.catalog import get_model_info
+
+        for model_id, expected_cutoff in [
+            ("claude-opus-4-6", "2024-08"),
+            ("claude-sonnet-4-5", "2024-08"),
+            ("gpt-5.2", "2024-04"),
+            ("gemini-3-pro-preview", "2024-12"),
+            ("gemini-3-flash-preview", "2024-12"),
+        ]:
+            info = get_model_info(model_id)
+            assert info is not None, f"Model {model_id} not found in catalog"
+            assert info.knowledge_cutoff == expected_cutoff, (
+                f"{model_id}: expected {expected_cutoff!r}, got {info.knowledge_cutoff!r}"
+            )
+
+    def test_build_environment_context_includes_knowledge_cutoff(self):
+        """build_environment_context() emits 'Knowledge cutoff:' when provided."""
+        from attractor_agent.env_context import build_environment_context
+
+        result = build_environment_context(
+            working_dir="/tmp",
+            model="claude-sonnet-4-5",
+            knowledge_cutoff="2024-08",
+            git_info={"is_git": False, "branch": "", "modified_count": 0,
+                      "untracked_count": 0, "recent_commits": []},
+        )
+        assert "Knowledge cutoff: 2024-08" in result
+
+    def test_build_environment_context_omits_cutoff_when_none(self):
+        """build_environment_context() must NOT emit 'Knowledge cutoff:' when None."""
+        from attractor_agent.env_context import build_environment_context
+
+        result = build_environment_context(
+            working_dir="/tmp",
+            model="claude-sonnet-4-5",
+            knowledge_cutoff=None,
+            git_info={"is_git": False, "branch": "", "modified_count": 0,
+                      "untracked_count": 0, "recent_commits": []},
+        )
+        assert "Knowledge cutoff" not in result


### PR DESCRIPTION
Three misc spec-compliance fixes validated by 9-model swarm review (9/9 APPROVE).

§11.11.5 — DoD route aliases in attractor_server/app.py
  Added /run (POST), /status/{id} (GET), /answer/{id} (POST) as aliases
  for the canonical /pipelines routes. /run and /status/{id} directly
  reuse the existing handlers. /answer/{id} uses a new dedicated handler
  _answer_first_question() that resolves the first pending question
  automatically (the alias has no {qid} path parameter).

§9.4.1 — ExecutionEnvironment introspection methods (environment.py)
  Added working_directory(), platform(), os_version() to the
  ExecutionEnvironment Protocol and both LocalEnvironment and
  DockerEnvironment. LocalEnvironment honours a working_dir constructor
  override; DockerEnvironment shells out pwd for working_directory() and
  uses "docker" as a placeholder for platform/os_version.

§9.8.2 — knowledge_cutoff wired into system prompt (catalog/env_context/session)
  Added knowledge_cutoff: str | None = None to ModelInfo frozen dataclass.
  All 7 catalog entries populated (Anthropic "2024-08", OpenAI "2024-04",
  Gemini "2024-12"). Wired into build_environment_context() which already
  accepted the parameter. Removed the TODO comment from session.py.

Tests (12 new in test_dod_gaps.py):
  - TestDoDRouteAliases: /status 404, /run 400 wired, /answer 404 unknown
  - TestExecutionEnvironmentIntrospection: platform, os_version, cwd, override
  - TestKnowledgeCutoffWiring: field, default, catalog values, env include/omit

Mock suite: 1482 passed, 3 xfailed.